### PR TITLE
Команда `init` крашится, если запущена из директории содержащей `package.json`

### DIFF
--- a/lib/help/getRootPath.js
+++ b/lib/help/getRootPath.js
@@ -1,19 +1,8 @@
-const appRoot = require('app-root-path');
 const upath = require('upath');
-const fs = require('fs');
 
 /**
  * Получить директорию с insales-uploader
  */
 export default function getRootPath() {
-  let root = upath.normalize(appRoot.path + '/node_modules/insales-uploader/');
-
-  try {
-    let stat = fs.statSync(upath.normalize(appRoot.path + '/package.json'));
-    root = appRoot.path;
-  } catch (e) {
-    //Файла не существует
-  }
-
-  return root;
+  return upath.normalize(__dirname + '/../..');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insales-uploader",
-  "version": "1.8.22",
+  "version": "1.8.23",
   "description": "InSales assets manager",
   "homepage": "https://github.com/insales/insales-uploader",
   "main": "dist/index.js",
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "ansi-colors": "^2.0.1",
-    "app-root-path": "^2.0.1",
     "babel-runtime": "^6.26.0",
     "color-support": "^1.1.3",
     "compare-versions": "^3.0.1",


### PR DESCRIPTION
Официальный путь — установка `insales-uploader` глобально. Но если я продвинутый пользователь и не хочу засорять глобальный скоуп пакетами и бинарником с очень общим названием `uploader`, в текущей версии есть баг определения пути до пакета `insales-uploader`.

### Как воспроизвести

1. Создать новый NPM-проект:
```bash
$ mkdir foo
$ cd foo
$ yarn init
```
2. Установить `insales-uploader`
```bash
$ yarn add --dev insales-uploader
```
3. Инициализировать файл настроек:
```bash
$ which uploader
./node_modules/.bin/uploader
$ uploader init
```

### Ожидаемое поведение

- В текущей директории появляется `insales-config.js`

### Действительное поведение

Краш:

```
Ошибка при создании файла настроек insales-config.js
{ NestedError: stat `/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js` failed: ENOENT: no such file or directory, stat '/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js'
    at Object.exports.statSync.path [as statSync] (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/fs.js:82:9)
    at copySyncNative (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:82:18)
    at Function.module.exports.sync (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:149:3)
    at Liftoff.invoke (/home/nailxx/devel/amperka-2018-theme/node_modules/insales-uploader/dist/cli/index.js:52:14)
    at Liftoff.execute (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:203:12)
    at module.exports (/home/nailxx/devel/amperka-2018-theme/node_modules/flagged-respawn/index.js:51:3)
    at Liftoff.<anonymous> (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:195:5)
    at /home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:165:9
    at /home/nailxx/devel/amperka-2018-theme/node_modules/v8flags/index.js:114:14
    at /home/nailxx/devel/amperka-2018-theme/node_modules/graceful-fs/graceful-fs.js:43:10
Caused By: Error: ENOENT: no such file or directory, stat '/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js'
    at Object.fs.statSync (fs.js:955:11)
    at Object.statSync (/home/nailxx/devel/amperka-2018-theme/node_modules/graceful-fs/polyfills.js:297:22)
    at Object.exports.statSync.path [as statSync] (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/fs.js:80:13)
    at copySyncNative (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:82:18)
    at Function.module.exports.sync (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:149:3)
    at Liftoff.invoke (/home/nailxx/devel/amperka-2018-theme/node_modules/insales-uploader/dist/cli/index.js:52:14)
    at Liftoff.execute (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:203:12)
    at module.exports (/home/nailxx/devel/amperka-2018-theme/node_modules/flagged-respawn/index.js:51:3)
    at Liftoff.<anonymous> (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:195:5)
    at /home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:165:9
  nested: 
   { Error: ENOENT: no such file or directory, stat '/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js'
    at Object.fs.statSync (fs.js:955:11)
    at Object.statSync (/home/nailxx/devel/amperka-2018-theme/node_modules/graceful-fs/polyfills.js:297:22)
    at Object.exports.statSync.path [as statSync] (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/fs.js:80:13)
    at copySyncNative (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:82:18)
    at Function.module.exports.sync (/home/nailxx/devel/amperka-2018-theme/node_modules/cp-file/index.js:149:3)
    at Liftoff.invoke (/home/nailxx/devel/amperka-2018-theme/node_modules/insales-uploader/dist/cli/index.js:52:14)
    at Liftoff.execute (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:203:12)
    at module.exports (/home/nailxx/devel/amperka-2018-theme/node_modules/flagged-respawn/index.js:51:3)
    at Liftoff.<anonymous> (/home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:195:5)
    at /home/nailxx/devel/amperka-2018-theme/node_modules/liftoff/index.js:165:9
     errno: -2,
     code: 'ENOENT',
     syscall: 'stat',
     path: '/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js' },
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/home/nailxx/devel/amperka-2018-theme/dist/options/defaults.js',
  name: '
```

### Как пофиксил

Вместо `appRoot` просто использовал `__dirname`, который нельзя запутать сторонними `package.json`.