### PR TITLE
Исправлена работа команды `uploader downloadFiles`

### DIFF
--- a/lib/insalesApi/listFile.js
+++ b/lib/insalesApi/listFile.js
@@ -13,10 +13,10 @@ export default function listFile (options, paths) {
       token: options.account.token,
       url: options.account.url
     }).then(response => {
-      let files = response.data.files.file.reduce((prev, curr)=> {
-        const name = upath.parse(curr['absolute-url']).base;
+      let files = response.data.reduce((prev, curr)=> {
+        const name = upath.parse(curr['absolute_url']).base;
         const path = upath.normalize(paths.files + '/' + name);
-        const url = curr['absolute-url'];
+        const url = curr['absolute_url'];
         return [...prev, {name,path,url}]
       }, []);
 
@@ -26,7 +26,7 @@ export default function listFile (options, paths) {
         console.log(err.msg);
       }
       console.log(err);
-      resole([]);
+      resolve([]);
     });
   })
 }


### PR DESCRIPTION
В текущей версии команда `uploader df` выдавала ошибку:
```
TypeError: Cannot read properties of undefined (reading 'file')
    at /Users/[...]/node_modules/insales-uploader/dist/insalesApi/listFile.js:39:39
```

 Судя по всему, изменился API.
